### PR TITLE
Update draft-holmer-rmcat-transport-wide-cc-extensions-01.txt

### DIFF
--- a/draft-holmer-rmcat-transport-wide-cc-extensions-01.txt
+++ b/draft-holmer-rmcat-transport-wide-cc-extensions-01.txt
@@ -344,8 +344,8 @@ Internet-Draft            trnsprt-wide-cc-exts              October 2015
 
    Note: In the case the base sequence number is decreased, creating a
    window overlapping the previous feedback messages, the status for any
-   packets previously reported as received must again be marked as
-   "Packet received" and the delta included again.
+   packets previously reported as received must be marked as "Packet not
+   received" and thus not delta included for that symbol.
 
 3.1.2.  Packet Status Chunks
 

--- a/draft-holmer-rmcat-transport-wide-cc-extensions-01.txt
+++ b/draft-holmer-rmcat-transport-wide-cc-extensions-01.txt
@@ -345,7 +345,7 @@ Internet-Draft            trnsprt-wide-cc-exts              October 2015
    Note: In the case the base sequence number is decreased, creating a
    window overlapping the previous feedback messages, the status for any
    packets previously reported as received must be marked as "Packet not
-   received" and thus not delta included for that symbol.
+   received" and thus no delta included for that symbol.
 
 3.1.2.  Packet Status Chunks
 


### PR DESCRIPTION
I'm not sure anymore, that it's a good idea to force the receiver to re-send statuses should the window slide backwards. Probably it would be better to always set these messages as "no received" if the status for the same sequence number shall be sent again. This will simplify for the receiver a lot, as it will not have to keep a history of already sent statuses... And the receiver will not have to keep a history if it wants to detect duplicates. WDYT?
